### PR TITLE
Correct regex

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -78,9 +78,8 @@ func (gc *Client) Auth(username, password string) error {
 		return err
 	}
 
-	re := regexp.MustCompile(`ticket=([^']+)'`)
+	re := regexp.MustCompile(`ticket=([^"]+)`)
 	ticket := re.FindAllStringSubmatch(string(body), 1)[0][1]
-
 	response, err = gc.client.Get(GARMIN_CONNECT_URL + "/post-auth/login?ticket=" + ticket)
 
 	if err != nil {


### PR DESCRIPTION
It seems like Garmin changed their login form without the patch I get the following error:

```
<redacted>";
	        var logintoken                   = "";
	        var social_uid                   = "
panic: Get https://connect.garmin.com/post-auth/login?ticket=ST-0577832-<redacted>";
	        var logintoken                   = "";
	        var social_uid                   = ": stream error: stream ID 1; PROTOCOL_ERROR

goroutine 1 [running]:
main.main()
	/Users/jscheuermann/private/workspace/garmin-connector/main.go:83 +0x1a1
exit status 2
```